### PR TITLE
feat: hook for course isStarted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+1.2.1 – 2023-08-03
+------------------
+* feat: hook for modify course enrollment data
+
 1.2.0 – 2023-07-18
 ------------------
 * Refactor `import_course_runs_metadata` command to import all courseruns

--- a/federated_content_connector/__init__.py
+++ b/federated_content_connector/__init__.py
@@ -2,4 +2,4 @@
 One-line description for README and other doc files.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'


### PR DESCRIPTION
**Description**
This PR adds a filter to identify whether the learner has started the course(external) or not and returns the results in `isStarted`

**JIRA**- [ENT-7373](https://2u-internal.atlassian.net/browse/ENT-7373) and [ENT-at 7374](https://2u-internal.atlassian.net/browse/ENT-7374)


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
