### PR TITLE
fix: resumeUrl for exec-ed courses in B2C dashboard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+1.3.1 – 2023-08-28
+------------------
+* fix: resumeUrl for exec-ed courses in B2C dashboard
+
 1.3.0 – 2023-08-18
 ------------------
 * feat: hook to modify courserun data for B2C dashboard

--- a/federated_content_connector/__init__.py
+++ b/federated_content_connector/__init__.py
@@ -2,4 +2,4 @@
 One-line description for README and other doc files.
 """
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/federated_content_connector/filters/pipeline.py
+++ b/federated_content_connector/filters/pipeline.py
@@ -107,6 +107,7 @@ class CreateApiRenderCourseRunStep(PipelineStep):
             course_details = CourseDetails.objects.get(id=serialized_courserun.get('courseId'))
             course_type = course_details.course_type
             product_source = course_details.product_source
+            homeUrl = serialized_courserun.get('homeUrl')
             start_date, end_date = course_details.start_date, course_details.end_date
 
             if product_source == PRODUCT_SOURCE_2U and course_type == EXEC_ED_COURSE_TYPE:
@@ -115,7 +116,8 @@ class CreateApiRenderCourseRunStep(PipelineStep):
                     'startDate': start_date,
                     'endDate': end_date,
                     'isStarted': now_utc > start_date if start_date is not None else True,
-                    'isArchived': now_utc > end_date if end_date is not None else False
+                    'isArchived': now_utc > end_date if end_date is not None else False,
+                    'resumeUrl': homeUrl
                 })
 
         except CourseDetails.DoesNotExist:


### PR DESCRIPTION
**Description**
While testing the learner dashboard, I discovered that the `Resume` button for EE courses was disabled. After debugging, I determined that the availability of this button is calculated based on the `resumeUrl`. Since we lack any data regarding resuming courses for executive education, I proceeded to replicate the getsmarter `homeUrl` into the `resumeUrl`. This adjustment enables the functionality of this button for EE courses. This will redirect the learner to the getsmarter dashboard by clicking the `Resume` button.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
