### PR TITLE
fix: remove inner function from `get_response_from_api`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+1.4.1 – 2023-09-13
+------------------
+* Remove inner function from `get_response_from_api`
+
 1.4.0 – 2023-09-12
 ------------------
 * Refactor to fetch course data using course uuid

--- a/federated_content_connector/__init__.py
+++ b/federated_content_connector/__init__.py
@@ -2,4 +2,4 @@
 One-line description for README and other doc files.
 """
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/federated_content_connector/course_metadata_importer.py
+++ b/federated_content_connector/course_metadata_importer.py
@@ -190,24 +190,17 @@ class CourseMetadataImporter:
         return results, courses.get('next'), courses.get('count')
 
     @classmethod
+    @backoff.on_exception(
+        backoff.expo,
+        Exception,
+        max_tries=3,
+        logger=logger,
+    )
     def get_response_from_api(cls, client, api_url):
         """
         Call api endpoint and return response.
         """
-
-        @backoff.on_exception(
-            backoff.expo,
-            Exception,
-            max_tries=3,
-            logger=logger,
-        )
-        def call_api():
-            """
-            Call api endpoint.
-            """
-            return client.get(api_url)
-
-        return call_api()
+        return client.get(api_url)
 
     @classmethod
     def process_courses_details(cls, courses_details, courserun_with_course_uuids):


### PR DESCRIPTION
**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
