### PR TITLE
fix: Update release note version number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 ----------
 
-1.4.5 – 2024-07-25
+1.5.1 – 2024-07-25
+------------------
+* Update release notes
+
+1.5.0 – 2024-07-25
 ------------------
 * Adds a `course_key` field to the `CourseDetails` model with a default value of an empty string
 

--- a/federated_content_connector/__init__.py
+++ b/federated_content_connector/__init__.py
@@ -2,4 +2,4 @@
 One-line description for README and other doc files.
 """
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'


### PR DESCRIPTION
Update release notes from 1.4.5 release to 1.5.0 release.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
